### PR TITLE
Add region selection page

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,4 +1,4 @@
-import "../styles/globals.css";
+import "../globals.css";
 import { useState, useEffect } from "react";
 import { PDFDocument, rgb, StandardFonts } from "pdf-lib";
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,46 @@
+import { useState } from "react";
+
+const regionesDeChile = [
+  "Arica y Parinacota",
+  "Tarapacá",
+  "Antofagasta",
+  "Atacama",
+  "Coquimbo",
+  "Valparaíso",
+  "Región Metropolitana de Santiago",
+  "O'Higgins",
+  "Maule",
+  "Ñuble",
+  "Biobío",
+  "La Araucanía",
+  "Los Ríos",
+  "Los Lagos",
+  "Aysén",
+  "Magallanes y de la Antártica Chilena"
+];
+
+export default function RegionSelector() {
+  const [region, setRegion] = useState("");
+
+  return (
+    <div style={{ padding: "2rem" }}>
+      <h1>Selección de Región</h1>
+      <label htmlFor="region">Seleccione su región:</label>
+      <select
+        id="region"
+        value={region}
+        onChange={(e) => setRegion(e.target.value)}
+        style={{ display: "block", marginTop: "1rem" }}
+      >
+        <option value="">-- Seleccione --</option>
+        {regionesDeChile.map((r) => (
+          <option key={r} value={r}>
+            {r}
+          </option>
+        ))}
+      </select>
+      {region && <p style={{ marginTop: "1rem" }}>Región seleccionada: {region}</p>}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add region selector page listing all Chilean regions
- move app bootstrap to `_app.js` and import global styles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b32431316883258911084de34c0c66